### PR TITLE
no-jira: MonotonicTickCount#timer yield start_tick to block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 12/09/2017
+### Added
+- Initial gem without release
+
+## [0.2.0] - 04/21/2020
+### Added
+- Add jenkins pipeline
+- Initial release
+
+## [0.2.1] - 07/09/2020
+### Added
+- MonotonicTickCount#timer: yield start_tick to block
+
+[0.2.0]: https://github.com/Invoca/monotonic_tick_count/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 12/09/2017
-### Added
-- Initial gem without release
+## [Unreleased]
 
-## [0.2.0] - 04/21/2020
-### Added
-- Add jenkins pipeline
-- Initial release
-
-## [0.2.1] - 07/09/2020
-### Added
+## [0.2.1] - 2020-07-09
+### Changed
 - MonotonicTickCount#timer: yield start_tick to block
 
+## [0.2.0] - 2020-04-21
+### Added
+- jenkins pipeline
+
+### Changed
+- prepared for initial release
+
+[Unreleased]: https://github.com/Invoca/monotonic_tick_count/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Invoca/monotonic_tick_count/releases/tag/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Invoca/monotonic_tick_count/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tick_count_b - tick_count_a => 900.0
 
 Finding the elapsed seconds of a block
 ```
-return_val, elapsed_seconds = MonotonicTickCount.timer do
+return_val, elapsed_seconds = MonotonicTickCount.timer do |start_tick|
   sleep(10)
   1
 end

--- a/lib/monotonic_tick_count.rb
+++ b/lib/monotonic_tick_count.rb
@@ -62,9 +62,9 @@ class MonotonicTickCount
 
     # yields to the caller and returns a pair: [result from yield, float time in seconds of block run]
     def timer
-      start = self.now
-      result = yield
-      [result, self.now - start]
+      start_tick = self.now
+      result = yield(start_tick)
+      [result, self.now - start_tick]
     end
   end
 end

--- a/lib/monotonic_tick_count/version.rb
+++ b/lib/monotonic_tick_count/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class MonotonicTickCount
-  VERSION = "0.2.0"
+  VERSION = "0.2.1.pre"
 end

--- a/lib/monotonic_tick_count/version.rb
+++ b/lib/monotonic_tick_count/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class MonotonicTickCount
-  VERSION = "0.2.1.pre"
+  VERSION = "0.2.1"
 end

--- a/spec/monotonic_tick_count_spec.rb
+++ b/spec/monotonic_tick_count_spec.rb
@@ -7,7 +7,7 @@ describe MonotonicTickCount do
     expect(::MonotonicTickCount::VERSION).to be
   end
 
-  context "#initialize" do
+  describe "#initialize" do
     it "should have a copy constructor" do
       tick_count1 = MonotonicTickCount.now
       tick_count2 = MonotonicTickCount.new(tick_count1)
@@ -36,7 +36,7 @@ describe MonotonicTickCount do
     end
   end
 
-  context "#-" do
+  describe "#-" do
     before do
       @tick_count1 = MonotonicTickCount.new(tick_count_f: 123.1)
     end
@@ -64,7 +64,7 @@ describe MonotonicTickCount do
     end
   end
 
-  context "#+" do
+  describe "#+" do
     before do
       @tick_count = MonotonicTickCount.new(tick_count_f: 123.1)
     end
@@ -91,7 +91,7 @@ describe MonotonicTickCount do
     end
   end
 
-  context "Comparable" do
+  describe "Comparable" do
     before do
       @tick_count1 = MonotonicTickCount.new(tick_count_f: 1.1)
       @tick_count2 = MonotonicTickCount.new(tick_count_f: 2.2)
@@ -116,7 +116,7 @@ describe MonotonicTickCount do
     end
   end
 
-  context "#hash" do
+  describe "#hash" do
     it "should delegate hash to tick_count_f" do
       tick_count1 = MonotonicTickCount.new(tick_count_f: 1.1)
       tick_count2 = MonotonicTickCount.new(tick_count_f: 1.1)
@@ -145,7 +145,7 @@ describe MonotonicTickCount do
     end
   end
 
-  context "#inspect" do
+  describe "#inspect" do
     it "should identify itself and have the tick count" do
       expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { 1234.012345 }
       tick_count = MonotonicTickCount.now
@@ -154,7 +154,7 @@ describe MonotonicTickCount do
   end
 
   context "class methods" do
-    context ".now" do
+    describe ".now" do
       it "should return an instance containing the current global monotonic tick counter" do
         expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { 1234.012345 }
         tick_count = MonotonicTickCount.now
@@ -162,12 +162,19 @@ describe MonotonicTickCount do
       end
     end
 
-    context ".timer" do
+    describe ".timer" do
       it "should return the result and elapsed seconds of the given block" do
         expect(MonotonicTickCount).to receive(:now).and_return(0.0, 2.718)
         result, duration = MonotonicTickCount.timer { 1 }
         expect(result).to be == 1
         expect(duration).to be == 2.718
+      end
+
+      it "yields the start_tick to the block" do
+        allow(MonotonicTickCount).to receive(:now).and_return(1.234)
+        MonotonicTickCount.timer do |start_tick|
+          expect(start_tick).to eq(1.234)
+        end
       end
     end
   end


### PR DESCRIPTION
Update `MonotonicTickCount.timer` to yield its `start_tick` to the provided block. Adds missing changelog. Bumps gem version to `0.2.1.pre`