### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'rspec', '~> 3.7'
 gem 'rspec_junit_formatter', '~> 0.4'
 gem 'rspec-mocks'
 gem 'rubocop', '0.54.0'
+gem 'simplecov', '~> 0.22'
+gem 'simplecov-lcov', '~> 0.8'
 
 
 gem "concurrent-ruby", "~> 1.0", "< 1.3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
+    docile (1.4.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
@@ -62,6 +63,13 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.11.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -85,6 +93,8 @@ DEPENDENCIES
   rspec-mocks
   rspec_junit_formatter (~> 0.4)
   rubocop (= 0.54.0)
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
 
 BUNDLED WITH
    2.6.3

--- a/gemfiles/activesupport_7_0.gemfile
+++ b/gemfiles/activesupport_7_0.gemfile
@@ -15,5 +15,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.3.0"
 gem "activesupport", "~> 7.0.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_7_1.gemfile
+++ b/gemfiles/activesupport_7_1.gemfile
@@ -15,5 +15,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.3.0"
 gem "activesupport", "~> 7.1.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_7_2.gemfile
+++ b/gemfiles/activesupport_7_2.gemfile
@@ -15,5 +15,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.3.0"
 gem "activesupport", "~> 7.2.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_8_0.gemfile
+++ b/gemfiles/activesupport_8_0.gemfile
@@ -15,5 +15,7 @@ gem "base64", ">= 0.2.0"
 gem "bigdecimal", ">= 3.1"
 gem "mutex_m", ">= 0.3.0"
 gem "activesupport", "~> 8.0.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "simplecov_helper"
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require "monotonic_tick_count"


### PR DESCRIPTION
## Summary
- Pass secrets: inherit to the shared ruby-test-matrix workflow so CODECOV_TOKEN reaches the Codecov upload step
- Add simplecov and simplecov-lcov (Gemfile, matching this repo's dev-dependency convention), loaded first in spec/spec_helper.rb via spec/simplecov_helper.rb; emits coverage/lcov.info when GITHUB_ACTIONS is set
- Update Gemfile.lock accordingly

## Coverage
Measured locally with Ruby 3.1.6: Line Coverage: 92.11% (35 / 38), 26 examples, 0 failures. lcov generation verified locally with GITHUB_ACTIONS=true.

codecov.yml not added: coverage is above 80%.